### PR TITLE
feat: add NAT gateway and private routing

### DIFF
--- a/terraform/modules/vpc/main.tf
+++ b/terraform/modules/vpc/main.tf
@@ -64,3 +64,45 @@ resource "aws_route_table_association" "public" {
   subnet_id      = each.value.id
   route_table_id = aws_route_table.public.id
 }
+
+# NAT Gateway (single NAT in first public subnet)
+resource "aws_eip" "nat" {
+  domain = "vpc"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-eip-nat"
+  })
+}
+
+resource "aws_nat_gateway" "this" {
+  allocation_id = aws_eip.nat.id
+  subnet_id     = values(aws_subnet.public)[0].id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-nat"
+  })
+
+  depends_on = [aws_internet_gateway.this]
+}
+
+# Private route table -> route 0.0.0.0/0 to NAT
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.this.id
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-rt-private"
+  })
+}
+
+resource "aws_route" "private_to_nat" {
+  route_table_id         = aws_route_table.private.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id         = aws_nat_gateway.this.id
+}
+
+resource "aws_route_table_association" "private" {
+  for_each = aws_subnet.private
+
+  subnet_id      = each.value.id
+  route_table_id = aws_route_table.private.id
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -13,3 +13,7 @@ output "private_subnet_ids" {
 output "igw_id" {
   value = aws_internet_gateway.this.id
 }
+
+output "nat_gateway_id" {
+  value = aws_nat_gateway.this.id
+}


### PR DESCRIPTION
Adds a single NAT Gateway (EIP + NAT) in a public subnet and routes private subnets outbound traffic via NAT. Includes private route table + associations.

Closes #4