### PR TITLE
feat: add ALB + target group + listener

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -40,3 +40,14 @@ module "security_groups" {
 
   tags = local.common_tags
 }
+
+module "alb" {
+  source = "./modules/alb"
+
+  name              = local.name
+  vpc_id            = module.vpc.vpc_id
+  public_subnet_ids = module.vpc.public_subnet_ids
+  alb_sg_id         = module.security_groups.alb_sg_id
+
+  tags = local.common_tags
+}

--- a/terraform/modules/alb/main.tf
+++ b/terraform/modules/alb/main.tf
@@ -1,0 +1,45 @@
+resource "aws_lb" "this" {
+  name               = "${var.name}-alb"
+  load_balancer_type = "application"
+  internal           = false
+
+  security_groups = [var.alb_sg_id]
+  subnets         = var.public_subnet_ids
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-alb"
+  })
+}
+
+resource "aws_lb_target_group" "app" {
+  name        = "${var.name}-tg-app"
+  port        = 80
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
+  target_type = "instance"
+
+  health_check {
+    path                = "/"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = 5
+    interval            = 30
+    matcher             = "200-399"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-tg-app"
+  })
+}
+
+resource "aws_lb_listener" "http" {
+  load_balancer_arn = aws_lb.this.arn
+  port              = 80
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.app.arn
+  }
+}

--- a/terraform/modules/alb/outputs.tf
+++ b/terraform/modules/alb/outputs.tf
@@ -1,0 +1,15 @@
+output "alb_arn" {
+  value = aws_lb.this.arn
+}
+
+output "alb_dns_name" {
+  value = aws_lb.this.dns_name
+}
+
+output "target_group_arn" {
+  value = aws_lb_target_group.app.arn
+}
+
+output "listener_arn" {
+  value = aws_lb_listener.http.arn
+}

--- a/terraform/modules/alb/variables.tf
+++ b/terraform/modules/alb/variables.tf
@@ -1,0 +1,9 @@
+variable "name" { type = string }
+variable "vpc_id" { type = string }
+variable "public_subnet_ids" { type = list(string) }
+variable "alb_sg_id" { type = string }
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -25,3 +25,11 @@ output "app_sg_id" {
 output "db_sg_id" {
   value = module.security_groups.db_sg_id
 }
+
+output "alb_dns_name" {
+  value = module.alb.alb_dns_name
+}
+
+output "alb_target_group_arn" {
+  value = module.alb.target_group_arn
+}


### PR DESCRIPTION
Adds an internet-facing ALB in public subnets with an HTTP listener and an app target group.

Closes #12