### PR TITLE
feat: add App EC2 in private subnet

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,6 @@ module "security_groups" {
   app_port = 80
   db_port  = 5432
 
-  # SSH açmak istersen kendi IP'ni /32 verirsin; şimdilik boş bırak (daha güvenli)
   admin_cidr_blocks = []
 
   tags = local.common_tags
@@ -48,6 +47,16 @@ module "alb" {
   vpc_id            = module.vpc.vpc_id
   public_subnet_ids = module.vpc.public_subnet_ids
   alb_sg_id         = module.security_groups.alb_sg_id
+
+  tags = local.common_tags
+}
+
+module "app" {
+  source = "./modules/app_ec2"
+
+  name      = local.name
+  subnet_id = module.vpc.private_subnet_ids[0] # şimdilik 1 instance
+  app_sg_id = module.security_groups.app_sg_id
 
   tags = local.common_tags
 }

--- a/terraform/modules/app_ec2/main.tf
+++ b/terraform/modules/app_ec2/main.tf
@@ -1,0 +1,30 @@
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64*"]
+  }
+}
+
+resource "aws_instance" "this" {
+  ami                    = data.aws_ami.al2023.id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = [var.app_sg_id]
+
+  user_data = <<-EOF
+              #!/bin/bash
+              set -e
+              dnf -y update
+              dnf -y install nginx
+              systemctl enable nginx
+              systemctl start nginx
+              echo "hello from ${var.name}" > /usr/share/nginx/html/index.html
+              EOF
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-app"
+  })
+}

--- a/terraform/modules/app_ec2/outputs.tf
+++ b/terraform/modules/app_ec2/outputs.tf
@@ -1,0 +1,7 @@
+output "instance_id" {
+  value = aws_instance.this.id
+}
+
+output "private_ip" {
+  value = aws_instance.this.private_ip
+}

--- a/terraform/modules/app_ec2/variables.tf
+++ b/terraform/modules/app_ec2/variables.tf
@@ -1,0 +1,13 @@
+variable "name" { type = string }
+variable "subnet_id" { type = string }
+variable "app_sg_id" { type = string }
+
+variable "instance_type" {
+  type    = string
+  default = "t3.micro"
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -33,3 +33,11 @@ output "alb_dns_name" {
 output "alb_target_group_arn" {
   value = module.alb.target_group_arn
 }
+
+output "app_instance_id" {
+  value = module.app.instance_id
+}
+
+output "app_private_ip" {
+  value = module.app.private_ip
+}


### PR DESCRIPTION
Adds a private EC2 instance as an app placeholder (nginx via user_data) using the existing app security group and private subnet.

Closes #14