### PR TITLE
feat: attach App EC2 to ALB target group

### DIFF
--- a/terraform/alb_attachments.tf
+++ b/terraform/alb_attachments.tf
@@ -1,0 +1,5 @@
+resource "aws_lb_target_group_attachment" "app" {
+  target_group_arn = module.alb.target_group_arn
+  target_id        = module.app.instance_id
+  port             = 80
+}


### PR DESCRIPTION
Registers the private app EC2 instance in the ALB target group (port 80). Completes the Internet -> ALB -> App traffic flow.

Closes #16