### PR TITLE
feat: enable SSM Session Manager for app EC2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -54,9 +54,10 @@ module "alb" {
 module "app" {
   source = "./modules/app_ec2"
 
-  name      = local.name
-  subnet_id = module.vpc.private_subnet_ids[0] # şimdilik 1 instance
-  app_sg_id = module.security_groups.app_sg_id
+  name                      = local.name
+  subnet_id                 = module.vpc.private_subnet_ids[0] # şimdilik 1 instance
+  app_sg_id                 = module.security_groups.app_sg_id
+  iam_instance_profile_name = aws_iam_instance_profile.app_ssm.name
 
   tags = local.common_tags
 }

--- a/terraform/modules/app_ec2/main.tf
+++ b/terraform/modules/app_ec2/main.tf
@@ -11,6 +11,7 @@ data "aws_ami" "al2023" {
 resource "aws_instance" "this" {
   ami                    = data.aws_ami.al2023.id
   instance_type          = var.instance_type
+  iam_instance_profile   = var.iam_instance_profile_name
   subnet_id              = var.subnet_id
   vpc_security_group_ids = [var.app_sg_id]
 

--- a/terraform/modules/app_ec2/variables.tf
+++ b/terraform/modules/app_ec2/variables.tf
@@ -11,3 +11,8 @@ variable "tags" {
   type    = map(string)
   default = {}
 }
+
+variable "iam_instance_profile_name" {
+  type    = string
+  default = null
+}

--- a/terraform/ssm.tf
+++ b/terraform/ssm.tf
@@ -1,0 +1,39 @@
+data "aws_iam_policy_document" "ec2_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "app_ssm" {
+  name               = "${local.name}-app-ssm-role"
+  assume_role_policy = data.aws_iam_policy_document.ec2_assume_role.json
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name}-app-ssm-role"
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "app_ssm_core" {
+  role       = aws_iam_role.app_ssm.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_instance_profile" "app_ssm" {
+  name = "${local.name}-app-ssm-profile"
+  role = aws_iam_role.app_ssm.name
+
+  tags = merge(local.common_tags, {
+    Name = "${local.name}-app-ssm-profile"
+  })
+}
+
+output "app_ssm_instance_profile_name" {
+  value = aws_iam_instance_profile.app_ssm.name
+}


### PR DESCRIPTION
Adds IAM role + instance profile for SSM and attaches it to the app EC2 instance.\n\nCloses #23